### PR TITLE
Substituição dos botões de start/end do itinerário pelo iniciar (demo)

### DIFF
--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -1,0 +1,16 @@
+.demo__button {
+  width: 15rem;
+  height: 5rem;
+  border: none;
+  display: block;
+  color: #fff;
+  border-radius: 10px;
+  padding: 1rem;
+  font-size: 1.2rem;
+  font-weight: bold;
+  position: absolute;
+  background-color: #FF7C00;
+  z-index: 1;
+  left: 90px;
+  bottom: 34px
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -1,5 +1,6 @@
 // Import your components CSS files here.
 @import "alert";
+@import "button";
 @import "avatar";
 @import "card";
 @import "form_legend_clear";

--- a/app/javascript/controllers/mapbox_controller.js
+++ b/app/javascript/controllers/mapbox_controller.js
@@ -38,7 +38,8 @@ export default class extends Controller {
       this.#fitMapToMarkers();
     })
 
-    this.map.addControl(directions);
+    this.map.addControl(directions, 'top-left');
+    // document.querySelector("mapboxgl-control-container").style.display = "none";
     this.readCoordinates();
   }
 

--- a/app/javascript/controllers/trip_controller.js
+++ b/app/javascript/controllers/trip_controller.js
@@ -12,7 +12,7 @@ export default class extends Controller {
 
   start() {
     if ("geolocation" in navigator) {
-      this.interval = setInterval(this.gps.bind(this), 1000)
+      this.interval = setInterval(this.gps.bind(this), 10000)
     } else {
       alert("I'm sorry, but geolocation services are not supported by your browser.");
     }

--- a/app/views/itineraries/show.html.erb
+++ b/app/views/itineraries/show.html.erb
@@ -1,13 +1,8 @@
-<h1>Itinerário</h1>
-
-<div data-controller="trip" data-trip-id-value="<%= @itinerary.id %>">
-  <button data-action="click->trip#start">Iniciar viagem</button>
-  <button data-action="click->trip#stop">Terminar viagem</button>
-</div>
-
-<div style="width: 100%; height: 600px;"
+<div style="width: 100vw; height: 92vh; position: relative;"
   data-controller="mapbox"
   data-mapbox-points-value="<%= @points.to_json %>"
   data-mapbox-markers-value="<%= @markers.to_json %>"
   data-mapbox-api-key-value="<%= ENV['MAPBOX_API_KEY'] %>"
-  data-mapbox-id-value="<%= @itinerary.id %>"></div>
+  data-mapbox-id-value="<%= @itinerary.id %>">
+  <button class="demo__button d-flex align-items-center justify-content-center"><i class="fas fa-location-arrow" style="color: #000; margin-right: .9rem; font-size: 1.5rem"></i>Iniciar</button>
+</div>


### PR DESCRIPTION
- Dado que faremos o fetch de um array pronto do novo controller stimulus, removi os botões de iniciar/temrinar viagem pois eles utilizavam a rota de update
- Acrescentei um botão no mapa que iniciará a demo (precisamos acrescentar depois um display none para ele quando clicado e não deve aparecer para os pais)